### PR TITLE
Fixed loading for item details, fixed explore bug

### DIFF
--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -66,15 +66,14 @@ const ExploreItems = () => {
         ))}
       </section>
       <div className="col-md-12 text-center">
-        {(showMore && collection.length) && (
-          <Link
-            to=""
+        {showMore && collection.length > 0 && (
+          <button
             id="loadmore"
             className="btn-main lead"
             onClick={() => loadMore()}
           >
             Load more
-          </Link>
+          </button>
         )}
       </div>
     </>

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -6,21 +6,25 @@ import { BASE_URL } from "../constants";
 
 const NFT_URL = BASE_URL + `itemDetails?nftId=`;
 const ItemDetails = () => {
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
   const { id } = useParams();
   const [nft, setNft] = useState([]);
+  const [loading, setLoading] = useState(false);
   async function getNft() {
+    setLoading(true);
     const { data } = await axios.get(`${NFT_URL + id}`);
     setNft(data);
+    setLoading(false);
   }
   useEffect(() => {
     getNft();
   }, []);
 
-  return nft ? (
+  return !loading ? (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>


### PR DESCRIPTION
**Task**: 
Resolve the 0 that appears upon refresh of the Explore page.
Resolve the lack of skeleton loading state in the Item Details page.

**Why**:
Smoothes user experience, minimizes confusion.

**How**:
Realized check for load button:: {showMore && collection.length && (...) was resulting in collection.length being briefly displayed, replaced it with collection.length > 0
Realized loading hook had not been set for Item Details component, added it and it worked.